### PR TITLE
feat: Parallel Github Package Releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,10 +4,11 @@ on:
   push:
     branches:
       - main
+      - md/github-pkg-release-action
 
 jobs:
-  release:
-    name: Release
+  publish_to_npm:
+    name: Publishing to npm registry
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
@@ -39,8 +40,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-  publish-gpr:
-    name: Publish on GitHub Packages
+  publish_to_github:
+    name: Publishing to github registry
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
@@ -50,13 +51,16 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: 16.x
+          registry-url: 'https://npm.pkg.github.com'
+          always-auth: true
+          scope: '@cldcvr'
 
       - name: Install Dependencies
         run: yarn
       - name: "Update Packages"
         env:
           GH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CUSTOM_REGISTRY_URL: "https://npm.pkg.github.com/@cldcvr"
         run: |
           git config user.name "${{ github.actor }}"
@@ -64,11 +68,19 @@ jobs:
           yarn update-packages
           git add -A
           git commit -m "Icons updated by GithubActions"
+      - name: Creating .npmrc
+        run: |
+          cat << EOF > "$HOME/.npmrc"
+            //npm.pkg.github.com/:_authToken=$NPM_TOKEN
+          EOF
+        env:
+          NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create Release Pull Request or Publish to Github Packages
         id: changesets
         uses: changesets/action@v1
         with:
-          publish: yarn release
+          publish: yarn release --no-git-tag
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - md/github-pkg-release-action
+      - md
 
 jobs:
   publish_to_npm:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Install Dependencies
         run: yarn
-      - name: "Update Packages" 
+      - name: "Update Packages"
         env:
           GH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -31,6 +31,40 @@ jobs:
           git add -A
           git commit -m "Icons updated by GithubActions"
       - name: Create Release Pull Request or Publish to npm
+        id: changesets
+        uses: changesets/action@v1
+        with:
+          publish: yarn release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  publish-gpr:
+    name: Publish on GitHub Packages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+
+      - name: Setup Node.js 16.x
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16.x
+
+      - name: Install Dependencies
+        run: yarn
+      - name: "Update Packages"
+        env:
+          GH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          CUSTOM_REGISTRY_URL: "https://npm.pkg.github.com/@cldcvr"
+        run: |
+          git config user.name "${{ github.actor }}"
+          git config user.email "vikas@cldcvr.com"
+          yarn update-packages
+          git add -A
+          git commit -m "Icons updated by GithubActions"
+      - name: Create Release Pull Request or Publish to Github Packages
         id: changesets
         uses: changesets/action@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - md
 
 jobs:
   publish_to_npm:

--- a/package-builder/create-packages.ts
+++ b/package-builder/create-packages.ts
@@ -8,6 +8,60 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 /**
+ *
+ * @param pkgName The npm package name
+ * @returns The valid `package.json` in **stringified** JSON
+ *
+ * NOTE: The registry can be decided by setting the `CUSTOM_REGISTRY_URL` env flag
+ */
+const generatePackageJsonContents = (pkgName: string) => {
+  return JSON.stringify(
+    {
+      name: pkgName,
+      version: "0.0.1",
+      description:
+        "This package contains free set icons to use in `@cldcvr/flow-core`",
+      main: "dist/flow-icon.es.js",
+      module: "dist/flow-icon.es.js",
+      types: "./dist/types/index.d.ts",
+      scripts: {
+        test: "echo 'Error: no test specified' && exit 1",
+        build: "vite build --emptyOutDir && tsc",
+        prepublishOnly: "yarn build"
+      },
+      keywords: ["icons"],
+      author: "@cldcvr",
+      license: "MIT",
+      dependencies: {
+        "@cldcvr/flow-core": "*"
+      },
+      devDependencies: {
+        axios: "^0.27.2",
+        fs: "^0.0.1-security",
+        "lit-html": "^2.2.7",
+        prettier: "^2.7.1",
+        typescript: "^4.7.4",
+        vite: "^3.0.4"
+      },
+      peerDependencies: {
+        "@cldcvr/flow-core": "*"
+      },
+      repository: {
+        type: "git",
+        url: "git+ssh://github.com/cldcvr/flow-icon.git"
+      },
+      publishConfig: {
+        access: process.env.CUSTOM_REGISTRY_URL ? "private" : "public",
+        registry:
+          process.env.CUSTOM_REGISTRY_URL ?? "https://registry.npmjs.org"
+      }
+    },
+    null,
+    2
+  );
+};
+
+/**
  * downloading icons
  */
 for (const pkg of config.packages) {
@@ -16,51 +70,8 @@ for (const pkg of config.packages) {
   const pkgJsonFilePath = `${__dirname}/../packages/${pkg.name}/package.json`;
 
   try {
-    if (!fs.existsSync(pkgJsonFilePath)) {
-      fs.writeFileSync(
-        pkgJsonFilePath,
-        `{
-				"name": "${pkg.name}",
-				"version": "0.0.1",
-				"description": "This package contains free set icons to use in \`@cldcvr/flow-core\`",
-				"main": "dist/flow-icon.es.js",
-				"module": "dist/flow-icon.es.js",
-				"types": "./dist/types/index.d.ts",
-				"scripts": {
-				  "test": "echo 'Error: no test specified' && exit 1",
-				  "build": "vite build --emptyOutDir && tsc",
-				  "prepublishOnly": "yarn build"
-				},
-				"keywords": [
-				  "icons"
-				],
-				"author": "@cldcvr",
-				"license": "MIT",
-				"dependencies": {
-				  "@cldcvr/flow-core": "*"
-				},
-				"devDependencies": {
-				  "axios": "^0.27.2",
-				  "fs": "^0.0.1-security",
-				  "lit-html": "^2.2.7",
-				  "prettier": "^2.7.1",
-				  "typescript": "^4.7.4",
-				  "vite": "^3.0.4"
-				},
-				"peerDependencies": {
-				  "@cldcvr/flow-core": "*"
-				},
-				"repository": {
-					"type": "git",
-					"url": "git+ssh://github.com/cldcvr/flow-icon.git"
-				  },
-				"publishConfig": {
-					"access": "public",
-					"registry": "https://registry.npmjs.org"
-				  }
-			  }`
-      );
-    }
+    if (!fs.existsSync(pkgJsonFilePath))
+      fs.writeFileSync(pkgJsonFilePath, generatePackageJsonContents(pkg.name));
 
     fs.writeFileSync(
       `${__dirname}/../packages/${pkg.name}/tsconfig.json`,
@@ -85,7 +96,7 @@ for (const pkg of config.packages) {
 			  "skipLibCheck": true,
 			  "target": "ESNext",
 			  "resolveJsonModule": true
-			},  
+			},
 			"include": ["./**/*.ts"],
 			"exclude": ["vite.config.ts"]
 		  }`

--- a/package-builder/create-packages.ts
+++ b/package-builder/create-packages.ts
@@ -27,13 +27,13 @@ const generatePackageJsonContents = (pkgName: string) => {
       scripts: {
         test: "echo 'Error: no test specified' && exit 1",
         build: "vite build --emptyOutDir && tsc",
-        prepublishOnly: "yarn build"
+        prepublishOnly: "yarn build",
       },
       keywords: ["icons"],
       author: "@cldcvr",
       license: "MIT",
       dependencies: {
-        "@cldcvr/flow-core": "*"
+        "@cldcvr/flow-core": "*",
       },
       devDependencies: {
         axios: "^0.27.2",
@@ -41,20 +41,20 @@ const generatePackageJsonContents = (pkgName: string) => {
         "lit-html": "^2.2.7",
         prettier: "^2.7.1",
         typescript: "^4.7.4",
-        vite: "^3.0.4"
+        vite: "^3.0.4",
       },
       peerDependencies: {
-        "@cldcvr/flow-core": "*"
+        "@cldcvr/flow-core": "*",
       },
       repository: {
         type: "git",
-        url: "git+ssh://github.com/cldcvr/flow-icon.git"
+        url: "git+ssh://github.com/cldcvr/flow-icon.git",
       },
       publishConfig: {
-        access: process.env.CUSTOM_REGISTRY_URL ? "private" : "public",
+        access: "public",
         registry:
-          process.env.CUSTOM_REGISTRY_URL ?? "https://registry.npmjs.org"
-      }
+          process.env.CUSTOM_REGISTRY_URL ?? "https://registry.npmjs.org",
+      },
     },
     null,
     2

--- a/packages/@cldcvr/flow-aws-icon/package.json
+++ b/packages/@cldcvr/flow-aws-icon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cldcvr/flow-aws-icon",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.1",
   "description": "This package contains free set icons to use in `@cldcvr/flow-core`",
   "main": "dist/flow-icon.es.js",
   "module": "dist/flow-icon.es.js",

--- a/packages/@cldcvr/flow-aws-icon/package.json
+++ b/packages/@cldcvr/flow-aws-icon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cldcvr/flow-aws-icon",
-  "version": "1.0.0",
+  "version": "1.0.0-alpha.1",
   "description": "This package contains free set icons to use in `@cldcvr/flow-core`",
   "main": "dist/flow-icon.es.js",
   "module": "dist/flow-icon.es.js",

--- a/packages/@cldcvr/flow-gcp-icon/package.json
+++ b/packages/@cldcvr/flow-gcp-icon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cldcvr/flow-gcp-icon",
-  "version": "1.0.0",
+  "version": "1.0.0-alpha.1",
   "description": "This package contains free set icons to use in `@cldcvr/flow-core`",
   "main": "dist/flow-icon.es.js",
   "module": "dist/flow-icon.es.js",

--- a/packages/@cldcvr/flow-gcp-icon/package.json
+++ b/packages/@cldcvr/flow-gcp-icon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cldcvr/flow-gcp-icon",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.1",
   "description": "This package contains free set icons to use in `@cldcvr/flow-core`",
   "main": "dist/flow-icon.es.js",
   "module": "dist/flow-icon.es.js",

--- a/packages/@cldcvr/flow-product-icon/package.json
+++ b/packages/@cldcvr/flow-product-icon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cldcvr/flow-product-icon",
-  "version": "1.0.1",
+  "version": "1.0.1-alpha.1",
   "description": "This package contains free set icons to use in `@cldcvr/flow-core`",
   "main": "dist/flow-icon.es.js",
   "module": "dist/flow-icon.es.js",

--- a/packages/@cldcvr/flow-product-icon/package.json
+++ b/packages/@cldcvr/flow-product-icon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cldcvr/flow-product-icon",
-  "version": "1.0.1-alpha.1",
+  "version": "1.0.2",
   "description": "This package contains free set icons to use in `@cldcvr/flow-core`",
   "main": "dist/flow-icon.es.js",
   "module": "dist/flow-icon.es.js",

--- a/packages/@cldcvr/flow-system-icon/package.json
+++ b/packages/@cldcvr/flow-system-icon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cldcvr/flow-system-icon",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.2",
   "description": "This package contains free set icons to use in `@cldcvr/flow-core`",
   "main": "dist/flow-icon.es.js",
   "module": "dist/flow-icon.es.js",

--- a/packages/@cldcvr/flow-system-icon/package.json
+++ b/packages/@cldcvr/flow-system-icon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cldcvr/flow-system-icon",
-  "version": "1.0.0",
+  "version": "1.0.0-alpha.1",
   "description": "This package contains free set icons to use in `@cldcvr/flow-core`",
   "main": "dist/flow-icon.es.js",
   "module": "dist/flow-icon.es.js",


### PR DESCRIPTION
### Checklist for raising a PR
- [x] Tested Locally
- [x] tested with alpha versions on actual flow-icons Repo


### Describe your PR
We can now release the npm packages onto Github packages as well. 
What was the use ?
- Unblocks internal teams from the `@cldcvr` namespace conflict while installing the flow-icons dependencies.

